### PR TITLE
Make all new nodes inherit alpha

### DIFF
--- a/richtext/richtext.lua
+++ b/richtext/richtext.lua
@@ -194,6 +194,7 @@ local function create_node(word, parent, font)
 	end
 	gui.set_pivot(node, gui.PIVOT_NW)
 	gui.set_parent(node, parent)
+	gui.set_inherit_alpha(node, true)
 	return node, metrics
 end
 


### PR DESCRIPTION
Now that Defold supports it, it makes sense to enable it by default, since fading text is a very common thing to do.