### PR TITLE
Rework parser to allow overlapping & nested tags. Add example.

### DIFF
--- a/example/example.gui
+++ b/example/example.gui
@@ -40,7 +40,7 @@ background_color {
 nodes {
   position {
     x: 120.0
-    y: 1097.0
+    y: 1130.0
     z: 0.0
     w: 1.0
   }

--- a/example/example.gui_script
+++ b/example/example.gui_script
@@ -91,22 +91,21 @@ local function create_truncate_example()
 	end)
 end
 
-local function wave_words(words)
+local function wave_words(words, notColor)
 	for _,wave in pairs(words) do
 		local chars = richtext.characters(wave)
 		gui.delete_node(wave.node)
 		for i,char in ipairs(chars) do
 			local pos = gui.get_position(char.node)
-			local pos_2 = gui.get_position(char.node)
-			pos_2.y = pos_2.y - 3
-			pos_2.x = pos_2.x + 2
-			gui.set_position(char.node, pos_2)
 			local amplitude = tonumber(wave.tags.wave) or 3
 			gui.animate(char.node, gui.PROP_POSITION, pos + vmath.vector3(0, amplitude, 0), gui.EASING_INOUTSINE, 0.6, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
-			gui.animate(char.node, "color.x", 0.9, gui.EASING_INOUTSINE, 0.2, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
-			gui.animate(char.node, "color.y", 0.9, gui.EASING_INOUTSINE, 0.6, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
-			gui.animate(char.node, "color.z", 0.9, gui.EASING_INOUTSINE, 10, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
-			gui.animate(char.node, "scale", 1.2, gui.EASING_INOUTSINE, 1.5, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
+			if not notColor then
+				gui.animate(char.node, "color.x", 0.9, gui.EASING_INOUTSINE, 0.2, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
+				gui.animate(char.node, "color.y", 0.9, gui.EASING_INOUTSINE, 0.6, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
+				gui.animate(char.node, "color.z", 0.9, gui.EASING_INOUTSINE, 10, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
+			end
+			local scale = gui.get_scale(char.node).x * 1.2
+			gui.animate(char.node, "scale", scale, gui.EASING_INOUTSINE, 1.5, i * 0.12112, nil, gui.PLAYBACK_LOOP_PINGPONG)
 		end
 	end
 end
@@ -147,6 +146,25 @@ local function create_nobreak_example()
 	richtext.create("The image at the end should end up on a new line <img=smileys:cyclops/>", "Roboto-Regular", settings_right)
 end
 
+local function create_overlapping_tags_example()
+	local settings_overlap = {
+		fonts = {
+			Roboto = {
+				regular = hash("Roboto-Regular"),
+				italic = hash("Roboto-Italic"),
+				bold = hash("Roboto-Bold"),
+				bold_italic = hash("Roboto-BoldItalic"),
+			},
+		},
+		position = vmath.vector3(0, 650, 0),
+	}
+	local text = "<size=0.5>You can even <i>overlap tags<size=0.65> like italic <b>bold italic : </i>bold regular</b> back to normal,\n" ..
+			"<color=red>or <color=#98e9f8>nest</color> tags with the <wave=1>same</size> name. Red text, <color=yellow>nested <b>" ..
+			"yellow,</color> back to</b> red,</color> no</wave>rmal."
+	local words = richtext.create(text, "Roboto", settings_overlap)
+	wave_words(richtext.tagged(words, "wave"), true)
+	return words
+end
 
 
 function init(self)
@@ -160,6 +178,7 @@ function init(self)
 	create_language_example()
 	create_nobreak_example()
 	self.clickable_words = create_clickable_words_example()
+	create_overlapping_tags_example()
 end
 
 

--- a/richtext/parse.lua
+++ b/richtext/parse.lua
@@ -3,64 +3,81 @@ local utf8 = require("richtext.utf8")
 
 local M = {}
 
-local function parse_tag(tag, params)
-	local settings = { tags = { [tag] = params } }
+
+local function shallow_copy(t)
+	if not t then
+		return {}
+	end
+	local new = {}
+	for k,v in pairs(t) do
+		new[k] = v
+	end
+	return new
+end
+
+
+-- get a table of word properties that the tag will modify
+local function get_tag_word_properties(tag, params)
+	local word_prop = { tags = { [tag] = params } }
 	if tag == "color" then
-		settings.color = color.parse(params)
+		word_prop.color = color.parse(params)
 	elseif tag == "font" then
-		settings.font = params
+		word_prop.font = params
 	elseif tag == "size" then
-		settings.size = tonumber(params)
+		word_prop.size = tonumber(params)
 	elseif tag == "b" then
-		settings.bold = true
+		word_prop.bold = true
 	elseif tag == "i" then
-		settings.italic = true
+		word_prop.italic = true
 	elseif tag == "a" then
-		settings.anchor = true
+		word_prop.anchor = true
 	elseif tag == "br" then
-		settings.linebreak = true
+		word_prop.linebreak = true
 	elseif tag == "img" then
 		local texture, anim = params:match("(.-):(.*)")
-		settings.image = {
+		word_prop.image = {
 			texture = texture,
 			anim = anim
 		}
 	elseif tag == "spine" then
 		local scene, anim = params:match("(.-):(.*)")
-		settings.spine = {
+		word_prop.spine = {
 			scene = scene,
 			anim = anim
 		}
 	elseif tag == "nobr" then
-		settings.nobr = true
+		word_prop.nobr = true
 	end
 
-	return settings
+	return word_prop
 end
 
 
 -- add a single word to the list of words
-local function add_word(text, settings, words)
-	local data = { text = text }
-	for k,v in pairs(settings) do
-		data[k] = v
+local function add_word(text, word_prop, words, dont_copy_data)
+	local data
+	if dont_copy_data then
+		data = word_prop
+	else
+		data = shallow_copy(word_prop)
+		data.text = text
 	end
 	words[#words + 1] = data
 end
 
 
--- split a line into words
-local function split_line(line, settings, words)
+-- split a line into words and add each word to the list with the current word properties
+local function split_line_and_add_words(line, word_prop, words)
 	assert(line)
-	assert(settings)
+	assert(word_prop)
 	assert(words)
-	local ws_start, trimmed_text, ws_end = line:match("^(%s*)(.-)(%s*)$")
+	local ws_start, trimmed_text, ws_end = line:match("^(%s*)(.-)(%s*)$") -- Trim any whitespace off either end.
 	if trimmed_text == "" then
-		add_word(ws_start .. ws_end, settings, words)
+		add_word(ws_start .. ws_end, word_prop, words)
 	else
 		local wi = #words
 		for word in trimmed_text:gmatch("%S+") do
-			add_word(word .. " ", settings, words)
+			add_word(word .. " ", word_prop, words)
 		end
 		local first = words[wi + 1]
 		first.text = ws_start .. first.text
@@ -71,16 +88,14 @@ end
 
 
 -- split text
--- split by lines first
-local function split_text(text, settings, words)
-	assert(text)
-	assert(settings)
-	assert(words)
-	-- special treatment of empty text with a linebreak <br/>
-	if text == "" and settings.linebreak then
-		add_word(text, settings, words)
+-- first split into lines, then split each line into words and add the words.
+local function split_text_and_add_words(text, word_prop, words)
+	if text == "" then
 		return
 	end
+	assert(text)
+	assert(word_prop)
+	assert(words)
 
 	-- we don't want to deal with \r\n, remove all \r
 	text = text:gsub("\r", "")
@@ -94,7 +109,7 @@ local function split_text(text, settings, words)
 
 	-- split into lines
 	for line in text:gmatch("(.-)\n") do
-		split_line(line, settings, words)
+		split_line_and_add_words(line, word_prop, words)
 		-- flag last word of a line as having a linebreak
 		local last = words[#words]
 		last.linebreak = true
@@ -108,77 +123,140 @@ local function split_text(text, settings, words)
 end
 
 
--- find tag in text
--- return the tag, tag params and any text before and after the tag
-local function find_tag(text)
-	assert(text)
-	-- find tag, end if no tag was found
-	local before_start_tag, tag, after_start_tag = text:match("(.-)(</?%S->)(.*)")
-	if not before_start_tag or not tag or not after_start_tag then
-		return nil
-	end
-
-	-- parse the tag, split into name and optional parameters
-	local name, params, empty = tag:match("<(%a+)=?(%S-)(/?)>")
-
-	-- empty tag, ie tag without content
-	-- example <br/> and <img=texture:image/>
-	if empty == "/" then
-		return before_start_tag, name, params, "", after_start_tag
-	end
-
-	-- find end tag
-	local inside_tag, after_end_tag = after_start_tag:match("(.-)</" .. name .. ">(.*)")
-	-- no end tag, treat the rest of the text as inside the tag
-	if not inside_tag then
-		return before_start_tag, name, params, after_start_tag, ""
-	-- end tag found
-	else
-		return before_start_tag, name, params, inside_tag, after_end_tag
-	end
+-- parse raw tag string into its name, params, and type flags
+local function parse_tag(tag)
+	local is_end_tag, name, params, is_empty_tag = tag:match("<(/?)(%a+)=?(%S-)(/?)>")
+	is_end_tag = is_end_tag == "/" or false
+	is_empty_tag = is_empty_tag == "/" or false
+	return is_end_tag, name, params, is_empty_tag
 end
 
+
+-- apply a tag's effects the current styling (`current_word_prop`)
+-- save the old state of the properties that were changed
+-- add special "words" for empty tags (images, etc.) to the word list
+local function apply_tag_to_state(tag, current_tags, tag_prop_history, current_word_prop, words)
+	local is_end_tag, name, params, is_empty_tag = parse_tag(tag)
+	assert(name, "Invalid tag sent to tag parser: '" .. tag .. "'.")
+
+	if is_end_tag then
+		-- find most recent tag with the same name and revert the properties it changed
+		local found_matching_tag = false
+		for i=#current_tags,1,-1 do
+			local old_tag_name = current_tags[i]
+			if old_tag_name == name then
+				found_matching_tag = true
+				table.remove(current_tags, i)
+				-- reset changed properties
+				local old_prop = tag_prop_history[i]
+				for k,v in pairs(old_prop) do
+					if k ~= "tags" then
+						current_word_prop[k] = v or nil
+					end
+				end
+				-- tags changed, need a new `tags` table
+				current_word_prop.tags = shallow_copy(current_word_prop.tags)
+				if old_prop.tags and old_prop.tags[name] then
+					current_word_prop.tags[name] = old_prop.tags[name]
+				else
+					current_word_prop.tags[name] = nil
+				end
+				if not next(current_word_prop.tags) then
+					current_word_prop.tags = nil
+				end
+				table.remove(tag_prop_history, i)
+				break
+			end
+		end
+		if not found_matching_tag then
+			print("WARNING: Defold-Richtext Parser: Found extra end tag: '" .. tag .. "'.")
+		end
+
+	elseif is_empty_tag then -- br, img, or spine - no closing tag for these
+		-- empty tags add their own special "word" and don't affect the current word properties
+		-- make our own word table just for the custom word
+		local word = shallow_copy(current_word_prop)
+		word.text = ""
+		-- add in properties from the tag
+		local tag_word_prop = get_tag_word_properties(name, params)
+		for k,v in pairs(tag_word_prop) do
+			if k ~= "tags" then
+				word[k] = v
+			end
+		end
+		word.tags = { [name] = tag_word_prop.tags[name] }
+		-- add the special word, using our word table directly instead of copying the current properties
+		add_word("", word, words, true, true)
+
+	else -- start tag
+		local tag_word_prop = get_tag_word_properties(name, params)
+		table.insert(current_tags, name)
+		-- get a table to store the old properties (reusing old ones)
+		local old_prop = tag_prop_history[#current_tags]
+		if not old_prop then -- add a new table if one doesn't exist for this index
+			old_prop = {}
+			table.insert(tag_prop_history, old_prop)
+		end
+		for k,v in pairs(old_prop) do -- clear the old table if it existed
+			old_prop[k] = nil
+		end
+		-- save old property values for the ones we are changing and set values in current_word_prop to the new ones.
+		for k,v in pairs(tag_word_prop) do
+			if k ~= "tags" then
+				old_prop[k] = current_word_prop[k] or false -- false will be converted to nil when the tag ends
+				current_word_prop[k] = v
+			end
+		end
+		-- tags changed, need a new `tags` table
+		current_word_prop.tags = shallow_copy(current_word_prop.tags)
+		if current_word_prop.tags[name] then
+			old_prop.tags = { [name] = current_word_prop.tags[name] }
+		end
+		current_word_prop.tags[name] = params
+	end
+end
 
 --- Parse the text into individual words
 -- @param text The text to parse
--- @param word_settings Default settings for each word
+-- @param default_word_prop Default properties for each word
 -- @return List of all words
-function M.parse(text, word_settings)
+
+-- Takes a string of tagged text and a table of default word properties.
+-- Returns a table containing a sequence of word objects/tables, containing
+--   the text and style properties for that word.
+function M.parse(text, default_word_prop)
 	assert(text)
-	assert(word_settings)
+	assert(default_word_prop)
+
 	local all_words = {}
+	local current_word_prop = shallow_copy(default_word_prop)
+	local current_tags = {} -- list of currently active tag names, from oldest at the start to newest at the end
+	local tag_prop_history = {} -- history of word properties as they were -before- the tag of the same index was applied
+
 	repeat
-		local before, tag, params, text_in_tag, after = find_tag(text)
-		-- no more tags? Split and add the entire string
+		local txt_before_tag, tag, txt_after_tag = text:match("(.-)(</?%S->)(.*)")
+
+		-- update the remaining text
+		if tag then
+			text = txt_after_tag
+		else
+			txt_before_tag = text
+			text = ""
+		end
+
+		-- split `txt_before_tag` into words and add them to the word list, with the current styling
+		split_text_and_add_words(txt_before_tag, current_word_prop, all_words)
+
 		if not tag then
-			split_text(text, word_settings, all_words)
 			break
 		end
 
-		-- split and add text before the encountered tag
-		if before ~= "" then
-			split_text(before, word_settings, all_words)
-		end
-
-		-- parse the tag and merge settings
-		local tag_settings = parse_tag(tag, params)
-		for k,v in pairs(word_settings) do
-			tag_settings[k] = tag_settings[k] or v
-		end
-		for tag,params in pairs(word_settings.tags or {}) do
-			tag_settings.tags[tag] = (params == "") and true or params
-		end
-
-		-- parse the text in the tag and add the words
-		local inner_words = M.parse(text_in_tag, tag_settings)
-		for _,word in ipairs(inner_words) do
-			all_words[#all_words + 1] = word
-		end
-
-		text = after
+		-- apply the tag to the current_word_prop, to be used next iteration (empty tag "words" get added immediately)
+		apply_tag_to_state(tag, current_tags, tag_prop_history, current_word_prop, all_words)
 	until text == ""
 	return all_words
 end
+
 
 --- Get the length of a text, excluding any tags (except image and spine tags)
 function M.length(text)


### PR DESCRIPTION
Will close issue #42. Hopefully I didn't break anything! All the examples work anyway. (And my MUD client works perfectly!)

**The parser can now:**
* Handle ending tags in non-reverse order:
    * `<color=red><b>some text</color></b>`
* Handle nested tags of the same name: 
    * `<color=red>red text <color=yellow>yellow</color> back to red.</color>`
* Overlapping tags and, in general, tags starting and ending in any order you like.
* If it gets an extra ending tag, it will print a warning. 

**Performance seems to be pretty good.**
* Tested recreating the example project repeatedly.
    * The new parser took 1.6% longer, on average, but the variance between each run was 25-30%, so I don't think that's a significant measurement.
    * With the same tags and examples, the new parser increases overall memory usage by ~2.7%.
    * Just measuring the parser, it was +3.5-8.9% more memory, but the stuff that usually comes after (creating nodes, etc.) takes up a lot more memory than that, so the overall impact isn't as much.
        * Taking advantage of the new flexibility to use fewer tags keeps things in the lower end of that 3.5-8.9% range.

**Example:**
There wasn't really room on the screen, but I stuffed in another example anyway to test the new parsing. 

I also tweaked the `wave_words` function a bit:
* Removed the inital pos setting. Not sure what that was for, but it was breaking the "amplitude" tag parameter for lower values.
* Added an optional argument to _not_ animate the color.
* Made the scale animation relative to the original scale of the letters.

**Non-required code changes:**
* Gave a couple of functions longer/different names so hopefully it's a bit easier to read through and figure out the code.
* Renamed some vars to refer to the contents of a "word" as "word properties" instead of "settings". Maybe I've had too much OOP, but reading "settings" just made it unclear to me. 
* Added way too many comments probably.