### PR TITLE
Update richtext.lua to add richtext.remove()

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,13 @@ Call this function when a click/touch has been detected and your text contains w
 * `consumed` (boolean) - True if any word was clicked.
 
 
+### richtext.remove(words)
+Removes all gui text nodes created by `richtext.create()`.
+
+**PARAMETERS**
+* `words` (table) - Table of words, as received from a call to `richtext.create()`.
+
+
 ### richtext.ALIGN_LEFT
 Left-align text. The words of a line starts at the specified position (see `richtext.create` settings above).
 

--- a/richtext/richtext.lua
+++ b/richtext/richtext.lua
@@ -638,7 +638,7 @@ end
 function M.remove(words)
 	assert(words)
 
-	local num = table.getn(words)
+	local num = #words
 	for i=1,num do
 		gui.delete_node(words[i].node)
 	end

--- a/richtext/richtext.lua
+++ b/richtext/richtext.lua
@@ -634,5 +634,15 @@ function M.characters(word)
 	return chars
 end
 
+---Removes the gui nodes created by rich text
+function M.remove(words)
+	assert(words)
+
+	local num = table.getn(words)
+	for i=1,num do
+		gui.delete_node(words[i].node)
+	end
+end
+
 
 return M


### PR DESCRIPTION
Added function richtext.remove(). It's trivial to loop over the words table and do it yourself, but it looks a bit cluttered when you are attempting to delete multiple rich text tables.