### PR TITLE
Added support for manually sized images

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ The following tags are supported:
 | font    | Change font                                    | `<font=MyCoolFont>Foobar</font>`            |
 | i       | The text should be italic                      | `<i>Foobar</i>`                             |
 | img     | Display image                                  | `<img=texture:image/>`                      |
-|		  | Display image in fixed square				   | `<img=texture:image,size>`					 |
-|		  | Display image in fixed rectangle			   | `<img=texture:image,width,height>`			 |
+|		  | Display image in fixed square				   | `<img=texture:image,size/>`				 |
+|		  | Display image in fixed rectangle			   | `<img=texture:image,width,height/>`		 |
 | nobr    | Prevent the text from breaking                 | `Words <nobr>inside tag</nobr> won't break` |
 | size    | Change text size, relative to default size     | `<size=2>Twice as large</size>`             |
 | spine   | Display spine model                            | `<spine=scene:anim/>`                       |
 | p       | Adds extra spacing below the line where this   | `<p>A paragraph</p>\nSome other text`       |
-|         | tag ends. Adds a newline before its opening    | `<p=2.5>This has 2.5 lines of spacing<p>`   |
+|         | tag ends. Adds a newline before its opening    | `<p=2.5>This has 2.5 lines of spacing</p>`  |
 |         | tag if it doesn't already exist.               |                                             |
 | repeat  | Repeat the text enclosed by the tag            | `<repeat=5>Echo </repeat> five times`       |
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The following tags are supported:
 | font    | Change font                                    | `<font=MyCoolFont>Foobar</font>`            |
 | i       | The text should be italic                      | `<i>Foobar</i>`                             |
 | img     | Display image                                  | `<img=texture:image/>`                      |
+|		  | Display image in fixed square				   | `<img=texture:image,size>`					 |
+|		  | Display image in fixed rectangle			   | `<img=texture:image,width,height>`			 |
 | nobr    | Prevent the text from breaking                 | `Words <nobr>inside tag</nobr> won't break` |
 | size    | Change text size, relative to default size     | `<size=2>Twice as large</size>`             |
 | spine   | Display spine model                            | `<spine=scene:anim/>`                       |

--- a/richtext/richtext.lua
+++ b/richtext/richtext.lua
@@ -194,7 +194,7 @@ local function create_box_node(word)
 	if image_width then
 		gui.set_size_mode(node, gui.SIZE_MODE_MANUAL)
 		size_vector.x = image_width
-		size_vector.y = image_height or image_width
+		size_vector.y = image_height
 		size_vector.z = 0
 		gui.set_size(node, size_vector)
 	else

--- a/richtext/richtext.lua
+++ b/richtext/richtext.lua
@@ -184,12 +184,29 @@ function M.length(text)
 end
 
 
+local size_vector = vmath.vector3()
 local function create_box_node(word)
 	local node = gui.new_box_node(V3_ZERO, V3_ZERO)
+	local word_image = word.image
+	local image_width = word_image.width
+	local image_height = word_image.height
 	gui.set_id(node, new_id("box"))
-	gui.set_size_mode(node, gui.SIZE_MODE_AUTO)
+	if image_width then
+		gui.set_size_mode(node, gui.SIZE_MODE_MANUAL)
+		size_vector.x = image_width
+		size_vector.y = image_height or image_width
+		size_vector.z = 0
+		gui.set_size(node, size_vector)
+	else
+		gui.set_size_mode(node, gui.SIZE_MODE_AUTO)
+	end
 	gui.set_texture(node, word.image.texture)
-	gui.set_scale(node, vmath.vector3(word.size))
+	local word_size = word.size
+	size_vector.x = word_size
+	size_vector.y = word_size
+	size_vector.z = word_size
+	gui.set_scale(node, size_vector)
+	
 	gui.play_flipbook(node, hash(word.image.anim))
 
 	-- get metrics of node based on image size

--- a/richtext/tags.lua
+++ b/richtext/tags.lua
@@ -63,25 +63,27 @@ M.register("nobr", function(params, settings)
 	settings.nobr = true
 end)
 
+-- Split string at first occurrence of token
+-- If the token doesn't exist the whole string is returned
+-- @param s The string to split
+-- @param token The token to split string on
+-- @return before The string before the token or the whole string if token doesn't exist
+-- @return after The string after the token or nul
+local function split(s, token)
+	if not s then return nil, nil end
+	local before, after = s:match("(.-)" .. token .. "(.*)")
+	before = before or s
+	return before, after
+end
+
 M.register("img", function(params, settings)
-	local texture, anim = params:match("(.-):(.*)")
-	local width, height
-	if anim then
-		temp_anim, width = anim:match("(.-),(.*)")
-		if temp_anim then
-			anim = temp_anim
-		end
-		if width then
-			temp_width, height = width:match("(.-),(.*)")
-			if temp_width then
-				width = temp_width
-			end
-			width = tonumber(width)
-			if height then
-				height = tonumber(height)
-			end	
-		end
-	end
+	local texture_and_anim, params = split(params, ",")
+	local width, params = split(params, ",")
+	local height, params = split(params, ",")
+	local texture, anim = split(texture_and_anim, ":")
+
+	width = width and tonumber(width)
+	height = height and tonumber(height) or width
 	
 	settings.image = {
 		texture = texture,

--- a/richtext/tags.lua
+++ b/richtext/tags.lua
@@ -65,9 +65,29 @@ end)
 
 M.register("img", function(params, settings)
 	local texture, anim = params:match("(.-):(.*)")
+	local width, height
+	if anim then
+		temp_anim, width = anim:match("(.-),(.*)")
+		if temp_anim then
+			anim = temp_anim
+		end
+		if width then
+			temp_width, height = width:match("(.-),(.*)")
+			if temp_width then
+				width = temp_width
+			end
+			width = tonumber(width)
+			if height then
+				height = tonumber(height)
+			end	
+		end
+	end
+	
 	settings.image = {
 		texture = texture,
-		anim = anim
+		anim = anim,
+		width = width,
+		height = height
 	}
 end)
 


### PR DESCRIPTION
These changes allow you to add optional comma-separated width,height parameters to img tags. If both are omitted, the box node will use auto size mode. If width and height are provided, the box node will be set to manual and use these as the x,y size (or if the height is omitted width will be used for both).