### PR TITLE
Pass tags with on_click msg

### DIFF
--- a/richtext/richtext.lua
+++ b/richtext/richtext.lua
@@ -589,7 +589,8 @@ function M.on_click(words, action)
 					node_id = gui.get_id(word.node),
 					text = word.text,
 					x = action.x, y = action.y,
-					screen_x = action.screen_x, screen_y = action.screen_y
+					screen_x = action.screen_x, screen_y = action.screen_y,
+					tags = word.tags
 				}
 				msg.post("#", word.tags.a, message)
 				return true


### PR DESCRIPTION
Modifies the `on_click` handler to pass the `word.tags` as part of the message. This allows you to send parameters along with the messages using custom tags rather than having a lot of duplicated code and having to embed parameters in the message_id itself.

Before:
```
<a=option_1>option 1</a>
<a=option_2>option 2</a>
```
etc.
...and then you'd need if message_id==hash("option_1") etc.

After:
```
<param=1><a=option>option 1</a></param>
<param=2><a=option>option 2</a></param>
```
etc.

...and now you can have a single handler for these options and parse the parameters. And you can stack the tags, etc. Lot of power for very minimal change.